### PR TITLE
Update internal reference to Scala-Rules to version 0.4.1

### DIFF
--- a/app/controllers/GlossariesController.scala
+++ b/app/controllers/GlossariesController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import javax.inject._
 
-import org.scalarules.engine.Fact
+import org.scalarules.facts.Fact
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import play.api.mvc._

--- a/app/services/DerivationsToGraphModel.scala
+++ b/app/services/DerivationsToGraphModel.scala
@@ -1,9 +1,10 @@
 package services
 
 import models.graph.{Graph, GraphEdge, GraphNode}
+import org.scalarules.derivations.DerivationTools._
+import org.scalarules.derivations.{DefaultDerivation, SubRunDerivation}
 import org.scalarules.dsl.nl.grammar.Berekening
-import org.scalarules.engine.DerivationTools._
-import org.scalarules.engine.{DefaultDerivation, Fact, SubRunDerivation}
+import org.scalarules.facts.Fact
 
 object DerivationsToGraphModel {
 

--- a/app/services/SourceAnnotator.scala
+++ b/app/services/SourceAnnotator.scala
@@ -2,8 +2,8 @@ package services
 
 import java.io.Writer
 
+import org.scalarules.derivations.Derivation
 import org.scalarules.dsl.nl.grammar.Berekening
-import org.scalarules.engine.Derivation
 import org.scalarules.utils.{FileSourcePosition, SourcePosition}
 
 import scala.annotation.tailrec

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val ruleViewer = (project in file("."))
 
 // *** Dependencies ***
 
-lazy val scalaRulesVersion = "0.3.4"
+lazy val scalaRulesVersion = "0.4.1"
 lazy val scalaTestVersion = "2.2.5"
 lazy val jodaTimeVersion = "2.4"
 lazy val jodaConvertVersion = "1.8"


### PR DESCRIPTION
We've noticed a weakness with the current deployment strategy. The viewer
incorporates a version of Scala-Rules which basically fixes its use to that
specific version. This commit creates a new version using Scala-Rules 0.4.1,
but we still need to create a better way to deal with this potential variable.