### PR TITLE
Adds a fix to the JarLoaderService originally made in rule-rest

### DIFF
--- a/app/services/JarLoaderService.scala
+++ b/app/services/JarLoaderService.scala
@@ -117,7 +117,7 @@ trait SpecializedClassLoader[T] {
   */
 class GlossaryClassLoader extends SpecializedClassLoader[Glossary] {
   // Note: since Glossaries are objects, we should only consider classes ending with a $, as per the Scala compiler's naming convention
-  override def precondition(className: String): Boolean = className.endsWith("$")
+  override def precondition(className: String): Boolean = className.endsWith("$") && className.collect { case ch: Char if ch == '$' => ch }.length == 1
 
   // Note: the dropRight(1) ensures the $-sign at the end of the name is removed. The Scala mirror will have no clue what to with the $ and simply requires the name of the object.
   override def preprocessClassName(className: String): String = className.dropRight(1)


### PR DESCRIPTION
The precondition function for Glossaries incorrectly identified nested
objects as potential Glossaries. While trying to load them, Java dies
because the outer object has not yet been loaded. This patch fixes the
issue in a somewhat ductapey way, but at least it works :)

TODO : Find a better way to identify objects/classes